### PR TITLE
IESecurity issue with 2012 R2 

### DIFF
--- a/scripts/Install-SP2016PreReqs.ps1
+++ b/scripts/Install-SP2016PreReqs.ps1
@@ -1,7 +1,14 @@
-﻿try {
+try {
     $ErrorActionPreference = "Stop"
 
     Start-Transcript -Path c:\cfn\log\Install-SP2016PreReqs.ps1.txt -Append
+
+    # because of https://community.spiceworks.com/topic/1991530-fixed-sharepoint-2016-never-installs-pre-requisites-properly
+	$AdminKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A7-37EF-4b3f-8CFC-4F3A74704073}"
+	$UserKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}"
+	Set-ItemProperty -Path $AdminKey -Name "IsInstalled" -Value 0
+	Set-ItemProperty -Path $UserKey -Name "IsInstalled" -Value 0
+	Stop-Process -Name Explorer -Confirm
 
     $driveLetter = Get-Volume | ?{$_.DriveType -eq 'CD-ROM'} | select -ExpandProperty DriveLetter
     if ($driveLetter.Count -gt 1) {

--- a/scripts/Install-SP2016PreReqs.ps1
+++ b/scripts/Install-SP2016PreReqs.ps1
@@ -4,11 +4,11 @@ try {
     Start-Transcript -Path c:\cfn\log\Install-SP2016PreReqs.ps1.txt -Append
 
     # because of https://community.spiceworks.com/topic/1991530-fixed-sharepoint-2016-never-installs-pre-requisites-properly
-	$AdminKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A7-37EF-4b3f-8CFC-4F3A74704073}"
-	$UserKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}"
-	Set-ItemProperty -Path $AdminKey -Name "IsInstalled" -Value 0
-	Set-ItemProperty -Path $UserKey -Name "IsInstalled" -Value 0
-	Stop-Process -Name Explorer -Confirm
+    $AdminKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A7-37EF-4b3f-8CFC-4F3A74704073}"
+    $UserKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}"
+    Set-ItemProperty -Path $AdminKey -Name "IsInstalled" -Value 0
+    Set-ItemProperty -Path $UserKey -Name "IsInstalled" -Value 0
+    Stop-Process -Name Explorer -Confirm
 
     $driveLetter = Get-Volume | ?{$_.DriveType -eq 'CD-ROM'} | select -ExpandProperty DriveLetter
     if ($driveLetter.Count -gt 1) {


### PR DESCRIPTION
Currently, this quick start template does not work with the error:
```
Microsoft Sync Framework Runtime is not installed.
```
After checking things out, it seems that a lot of dependencies were not installed. I was running the dependencies script manually and nothing happened, still a lot of things were not installed. Disabled IE Enhanced security, rerun the dependencies script, and the dependencies seems to be installed now. 